### PR TITLE
Struct for mapping silicon scorer output

### DIFF
--- a/NPSimulation/Core/SiliconScorers.hh
+++ b/NPSimulation/Core/SiliconScorers.hh
@@ -35,16 +35,16 @@ namespace SILICONSCORERS {
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
   struct RectangularOutput {
-    double totalEnergy;
-    double globalTime;
-    double x;
-    double y;
-    double z;
-    double theta;
-    double phi;
-    double detectorNumber;
-    double stripLengthNumber;
-    double stripWidthNumber;
+    G4double totalEnergy;
+    G4double globalTime;
+    G4double x;
+    G4double y;
+    G4double z;
+    G4double theta;
+    G4double phi;
+    G4double detectorNumber;
+    G4double stripLengthNumber;
+    G4double stripWidthNumber;
   };
 
   class PS_Silicon_Rectangle : public G4VPrimitiveScorer{
@@ -90,17 +90,17 @@ namespace SILICONSCORERS {
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
   struct AnnularOutput {
-    double totalEnergy;
-    double globalTime;
-    double x;
-    double y;
-    double z;
-    double theta;
-    double phi;
-    double detectorNumber;
-    double stripRingNumber;
-    double stripSectorNumber;
-    double stripQuadrantNumber;
+    G4double totalEnergy;
+    G4double globalTime;
+    G4double x;
+    G4double y;
+    G4double z;
+    G4double theta;
+    G4double phi;
+    G4double detectorNumber;
+    G4double stripRingNumber;
+    G4double stripSectorNumber;
+    G4double stripQuadrantNumber;
   };
 
   class PS_Silicon_Annular : public G4VPrimitiveScorer{
@@ -150,16 +150,16 @@ namespace SILICONSCORERS {
   };
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
   struct ResistiveOutput {
-    double upstreamEnergy;
-    double downstreamEnergy;
-    double globalTime;
-    double detectorNumber;
-    double stripWidthNumber;
-    double x;
-    double y;
-    double z;
-    double theta;
-    double phi;
+    G4double upstreamEnergy;
+    G4double downstreamEnergy;
+    G4double globalTime;
+    G4double detectorNumber;
+    G4double stripWidthNumber;
+    G4double x;
+    G4double y;
+    G4double z;
+    G4double theta;
+    G4double phi;
   };
 
   class PS_Silicon_Resistive : public G4VPrimitiveScorer{

--- a/NPSimulation/Core/SiliconScorers.hh
+++ b/NPSimulation/Core/SiliconScorers.hh
@@ -32,13 +32,27 @@ using namespace std;
 using namespace CLHEP;
 
 namespace SILICONSCORERS {
-//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......  
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+  struct RectangularOutput {
+    double totalEnergy;
+    double globalTime;
+    double x;
+    double y;
+    double z;
+    double theta;
+    double phi;
+    double detectorNumber;
+    double stripLengthNumber;
+    double stripWidthNumber;
+  };
+
   class PS_Silicon_Rectangle : public G4VPrimitiveScorer{
     
   public: // with description
     PS_Silicon_Rectangle(G4String name, G4int Level, G4double StripPlaneLength, G4double StripPlaneWidth, G4int NumberOfStripLength,G4int NumberOfStripWidth,G4int depth=0,G4String axis="xy");
      ~PS_Silicon_Rectangle();
-    
+
   protected: // with description
      G4bool ProcessHits(G4Step*, G4TouchableHistory*);
     
@@ -74,6 +88,21 @@ namespace SILICONSCORERS {
   };
   
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+  struct AnnularOutput {
+    double totalEnergy;
+    double globalTime;
+    double x;
+    double y;
+    double z;
+    double theta;
+    double phi;
+    double detectorNumber;
+    double stripRingNumber;
+    double stripSectorNumber;
+    double stripQuadrantNumber;
+  };
+
   class PS_Silicon_Annular : public G4VPrimitiveScorer{
     
   public: // with description
@@ -120,6 +149,19 @@ namespace SILICONSCORERS {
     
   };
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+  struct ResistiveOutput {
+    double upstreamEnergy;
+    double downstreamEnergy;
+    double globalTime;
+    double detectorNumber;
+    double stripWidthNumber;
+    double x;
+    double y;
+    double z;
+    double theta;
+    double phi;
+  };
+
   class PS_Silicon_Resistive : public G4VPrimitiveScorer{
     
   public: // with description


### PR DESCRIPTION
This adds structs mapping for the scorer output. 

Hence in the ReadSensitive part of the tutorial this line

```
G4double* Info = *(Strip_itr->second);
```

could be change to this:
```
RectangularOutput* Info = (RectangularOutput*) *(Strip_itr->second);
```